### PR TITLE
Note on using container/alias for (older) apb

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@
 - local [catasb](https://github.com/fusor/catasb) or similar oc cluster, which is configured to read from your docker org.
 
 **NOTE:**
-Due to using an older version of the ASB, it is recommended using the `apb` like the following:
+Due to our usage of an older version of the ASB, it is recommended using the `apb` CLI like the following:
 
 ```bash
 alias apb='docker run --rm --privileged -v $PWD:/mnt -v $HOME/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $UID docker.io/feedhenry/apb'
 ```
 
-Instead of the `abp` alias, you might want to use a modified alias, such as `apb-fh`, to not conflict w/ other versions that might be installed. 
-
+Instead of the `abp` alias, you might want to use a modified alias, such as `apb-fh`, to not conflict w/ other versions that might be installed already on your machine.
 
 ### Process
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@
 - [apb](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/README.md#installing-the-apb-tool)
 - local [catasb](https://github.com/fusor/catasb) or similar oc cluster, which is configured to read from your docker org.
 
+**NOTE:**
+Due to using an older version of the ASB, it is recommended using the `apb` like the following:
+
+```bash
+alias apb='docker run --rm --privileged -v $PWD:/mnt -v $HOME/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $UID docker.io/feedhenry/apb'
+```
+
+Instead of the `abp` alias, you might want to use a modified alias, such as `apb-fh`, to not conflict w/ other versions that might be installed. 
+
+
 ### Process
 
 After making your required changes, update the `apb.yml` to point at your own docker organisation, run:


### PR DESCRIPTION
Until we are able to use the latest greats APB cli (e.g. via the Ansible's own container), we might want to use our own (customer) apb container.

Adding a note to use it w/ an `apb-fh` alias... 