### PR TITLE
Copy app_id script to /tmp

### DIFF
--- a/roles/bind-3scale-apb/tasks/main.yml
+++ b/roles/bind-3scale-apb/tasks/main.yml
@@ -3,6 +3,11 @@
     src: ../files/bind.sh
     dest: /tmp/
 
+- name: Create app_id.sh
+  copy:
+    src: ../files/app_id.sh
+    dest: /tmp/
+
 - name: Make bind script executable
   file:
     dest: /tmp/bind.sh


### PR DESCRIPTION
Currently we try to call the app_id script but it isn't there