### PR TITLE
Adding release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ DOCKERORG = feedhenry
 TAG = latest
 USER=$(shell id -u)
 PWS=$(shell pwd)
+LAST_COMMIT=$(shell git rev-parse HEAD)
+ORIGIN = origin
 
 build_and_push: apb_build docker_push apb_push
 
@@ -22,3 +24,16 @@ docker_push:
 apb_push:
 	docker run --rm --privileged -v $(PWD):/mnt:z -v $(HOME)/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $(USER) docker.io/ansibleplaybookbundle/apb:latest push
 
+.PHONY: apb_release
+apb_release:
+    ifdef VERSION
+		@echo "Preparing $(VERSION)"
+    else
+		$(error No VERSION defined!)
+    endif
+    ifeq ($(shell git ls-files -m | wc -l),0)
+		@echo 'tagging for $(LAST_COMMIT)'
+		git tag -a $(VERSION) $(LAST_COMMIT) -m "signing tag" && git push $(ORIGIN) $(VERSION)
+    else
+	    $(error Aborting release process, since local files are modified)
+    endif


### PR DESCRIPTION
Added a release `target` to the `Makefile`, to automate releases

Usage:
```bash
make apb_release VERSION=foobar-2 ORIGIN=matzew
```

**DISCUSS:** the default for the `$(ORIGIN)` variable is `origin`... or should we go w/ `upstream` ? I guess we don't really have 'rules' for git usages, such as: https://aerogear.org/docs/guides/GitHubWorkflow/